### PR TITLE
show number of hymns received_by person in advanced search

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 use App\Models\HymnTranslation;
 use App\Models\Person;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class SearchController extends Controller
 {
@@ -14,6 +15,7 @@ class SearchController extends Controller
         $contains = $this->sanitizeSearchTerms($request->get('hymn_contains'));
 
         $receivedBy = $request->get('received_by', '');
+        // dd($receivedBy);
         $offeredTo = $request->get('offered_to', '');
 
         if (!empty($request->get('hymn_contains'))) {
@@ -37,7 +39,11 @@ class SearchController extends Controller
             $hymnTranslations = collect( [] );
         }
 
-        $people = Person::orderBy('display_name')->get();
+        $people = Person::leftJoin('hymns', 'received_by', '=', 'persons.id')
+            ->groupBy(['persons.display_name', 'persons.id'])
+            ->select('persons.id', 'display_name', DB::raw('count(hymns.id) as hymns_count'))
+            ->orderBy('display_name')
+            ->get();
 
         return view('advanced_search', [
             'people' => $people,

--- a/resources/views/advanced_search.blade.php
+++ b/resources/views/advanced_search.blade.php
@@ -31,7 +31,7 @@
                         @foreach($people as $person)
                             <option value="{{ $person->id }}"
                                 @if ($receivedBy == $person->id) SELECTED @endif
-                            >{{ $person->display_name }}</option>
+                            >{{ $person->display_name }} ({{ $person->hymns_count }})</option>
                         @endforeach
                     </select>
                 </div>


### PR DESCRIPTION
I made one quick update; putting the number of hymns per received_by in parentheses in the search box - I was confused that the search was broken at first:

![image](https://user-images.githubusercontent.com/1443928/208278754-7e9e7d8a-d0c4-4504-82ff-d7396621e851.png)
