### PR TITLE
some error fixes in the site

### DIFF
--- a/app/Http/Controllers/HinarioController.php
+++ b/app/Http/Controllers/HinarioController.php
@@ -7,6 +7,7 @@ use App\Models\UserHinario;
 use App\Services\GlobalFunctions;
 use App\Services\HinarioService;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Mpdf\Mpdf;
 
 class HinarioController extends Controller
@@ -40,6 +41,8 @@ class HinarioController extends Controller
     public function showPreloaded($hinarioId, $hinarioName = null)
     {
         $hinario = Hinario::where('id', $hinarioId)->first();
+        // Log::info($hinarioId);
+        // Log::info($hinario);
 
         GlobalFunctions::setActiveHinario($hinarioId);
 
@@ -50,14 +53,15 @@ class HinarioController extends Controller
             $userHinarios = [];
         }
 
-        $displaySections = count($hinario->getSections()) > 1;
+        // $displaySections = count($hinario->getSections()) > 1;
 
-        if (empty($hinario->preloaded_json)) {
+        if (!is_null($hinario) && empty($hinario->preloaded_json)) {
             $this->hinarioService->preloadHinario($hinarioId);
             $hinario->refresh();
         }
 
-        $hinarioData = json_decode($hinario->preloaded_json);
+        $hinarioData = !is_null($hinario) ? json_decode($hinario->preloaded_json) : null;
+        // Log::info($hinarioData);
 
         return view('hinarios.hinario',
             [

--- a/app/Services/HinarioService.php
+++ b/app/Services/HinarioService.php
@@ -8,9 +8,14 @@ class HinarioService
 {
     public function preloadHinario($hinarioId)
     {
+        
         $hinarioModel = Hinario::where('id', $hinarioId)
             ->with('translations', 'sections', 'hymns', 'hymnHinarios', 'hymnHinarios.hinario', 'receivedBy', 'hymns.mediaFiles', 'hymns.translations', 'hymns.hymnHinarios')
             ->first();
+
+        if(is_null($hinarioModel)) {
+            return;
+        }
 
         $recordingSourceModels = $hinarioModel->getRecordingSources();
 

--- a/resources/views/hinarios/hinario.blade.php
+++ b/resources/views/hinarios/hinario.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('header_title')
-    {{ $hinario->name }}
+    {{ !is_null($hinario) ? $hinario->name : null }}
 @endsection
 
 @section('panzer')
@@ -17,37 +17,40 @@
 @endsection
 
 @section('page_title')
-    @if (strlen($hinario->name) > 25)
-        <div class="hinario-header">
+    @if(!is_null($hinario))
+
+        @if (strlen($hinario->name) > 25)
+            <div class="hinario-header">
+                <h2 class="small display_table_cell_md">
+                    {{ $hinario->name }}
+                </h2>
+            </div>
+        @else
             <h2 class="small display_table_cell_md">
                 {{ $hinario->name }}
+        @endif
+
+            <ol class="breadcrumb display_table_cell_md">
+                @if ($hinario->name != $hinarioModel->getName())
+                    <li>
+                        {{ $hinarioModel->getName() }}
+                    </li>
+                @endif
+                @if ($hinario->type_id == 1 && !empty($hinario->receivedBy))
+                    <li>
+                        {{ __('hymns.header.received_by') }} <a href="{{ url($hinario->receivedBy->slug) }}">{{ $hinario->receivedBy->display_name }}</a>
+                    </li>
+                @endif
+                <li>
+                    <a href="{{ url($hinario->slug . '/pdf') }}" target="_blank" style="color: #fac400;">{{ __('hinarios.pdf.link_text') }}</a>
+                </li>
+            </ol>
+
+        @if (strlen($hinario->name) > 25)
             </h2>
-        </div>
-    @else
-        <h2 class="small display_table_cell_md">
-            {{ $hinario->name }}
+        @endif
+
     @endif
-
-        <ol class="breadcrumb display_table_cell_md">
-            @if ($hinario->name != $hinarioModel->getName())
-                <li>
-                    {{ $hinarioModel->getName() }}
-                </li>
-            @endif
-            @if ($hinario->type_id == 1 && !empty($hinario->receivedBy))
-                <li>
-                    {{ __('hymns.header.received_by') }} <a href="{{ url($hinario->receivedBy->slug) }}">{{ $hinario->receivedBy->display_name }}</a>
-                </li>
-            @endif
-            <li>
-                <a href="{{ url($hinario->slug . '/pdf') }}" target="_blank" style="color: #fac400;">{{ __('hinarios.pdf.link_text') }}</a>
-            </li>
-        </ol>
-
-    @if (strlen($hinario->name) > 25)
-        </h2>
-    @endif
-
 @endsection
 
 @section('content')
@@ -56,36 +59,38 @@
         @php
             $sectionName = ''
         @endphp
-        @foreach ($hinario->hymnHinarios as $hymnHinario)
-            @if ($hinario->displaySections && $hymnHinario->section != $sectionName)
-                <div class="row">
-                    <div class="hinario-section-name">{{ $hymnHinario->section }}</div>
-                </div>
-                @php
-                    $sectionName = $hymnHinario->section
-                @endphp
-            @endif
-            <div class="hymn-list-name">
-                <a href="{{ url($hymnHinario->hymn->slug) }}">
-                    {{ $hymnHinario->list_order }}.
-                    @if (strlen($hymnHinario->hymn->name) > 30)
-                        @php
-                            $closestSpace = strpos($hymnHinario->hymn->name, ' ', 23);
-                        @endphp
-                        {!! mb_convert_case(substr_replace($hymnHinario->hymn->name, '<br>', $closestSpace, 0), MB_CASE_TITLE, "UTF-8") !!}
-                    @else
-                        {{ mb_convert_case($hymnHinario->hymn->name, MB_CASE_TITLE, "UTF-8") }}
-                    @endif
-                </a>
-                @if (\Illuminate\Support\Facades\Auth::check())
-                    <ul class="nav navbar-nav navbar-right add-hymn">
-                        <li class="dropdown">
-                            @include('layouts.partials.add_hymn_form', [ 'hymn' => $hymnHinario->hymn ])
-                        </li>
-                    </ul>
+        @if(!is_null($hinario))
+            @foreach ($hinario->hymnHinarios as $hymnHinario)
+                @if ($hinario->displaySections && $hymnHinario->section != $sectionName)
+                    <div class="row">
+                        <div class="hinario-section-name">{{ $hymnHinario->section }}</div>
+                    </div>
+                    @php
+                        $sectionName = $hymnHinario->section
+                    @endphp
                 @endif
-            </div>
-        @endforeach
+                <div class="hymn-list-name">
+                    <a href="{{ url($hymnHinario->hymn->slug) }}">
+                        {{ $hymnHinario->list_order }}.
+                        @if (strlen($hymnHinario->hymn->name) > 30)
+                            @php
+                                $closestSpace = strpos($hymnHinario->hymn->name, ' ', 23);
+                            @endphp
+                            {!! mb_convert_case(substr_replace($hymnHinario->hymn->name, '<br>', $closestSpace, 0), MB_CASE_TITLE, "UTF-8") !!}
+                        @else
+                            {{ mb_convert_case($hymnHinario->hymn->name, MB_CASE_TITLE, "UTF-8") }}
+                        @endif
+                    </a>
+                    @if (\Illuminate\Support\Facades\Auth::check())
+                        <ul class="nav navbar-nav navbar-right add-hymn">
+                            <li class="dropdown">
+                                @include('layouts.partials.add_hymn_form', [ 'hymn' => $hymnHinario->hymn ])
+                            </li>
+                        </ul>
+                    @endif
+                </div>
+            @endforeach
+        @endif
     </div>
     <!--eof .col-sm-8 (main content)-->
     <!-- tabs -->

--- a/resources/views/hinarios/partials/audio_block_display_nav.blade.php
+++ b/resources/views/hinarios/partials/audio_block_display_nav.blade.php
@@ -1,4 +1,4 @@
-@if (count($hinario->recordingSources) > 0)
+@if (!is_null($hinario) && count($hinario->recordingSources) > 0)
     <div class="row vertical-tabs color4">
         <!-- Nav tabs -->
         <ul class="nav less-padding" role="tablist">

--- a/resources/views/hinarios/partials/audio_block_display_tabs.blade.php
+++ b/resources/views/hinarios/partials/audio_block_display_tabs.blade.php
@@ -1,4 +1,4 @@
-@if (count($hinario->recordingSources) > 0)
+@if (!is_null($hinario) && count($hinario->recordingSources) > 0)
     <div class="vertical-tabs color3">
         <div class="tab-content hinario-player-tab" style="background-color: white;">
             @foreach ($hinario->recordingSources as $source)

--- a/resources/views/hymns/hymn.blade.php
+++ b/resources/views/hymns/hymn.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app')
 
 @section('header_title')
-    {{ mb_convert_case($hymn->getName(), MB_CASE_TITLE, 'UTF-8') }}
+    {{ !is_null($hymn) ? mb_convert_case($hymn->getName(), MB_CASE_TITLE, 'UTF-8') : null }}
 @endsection
 
 @section('panzer')
@@ -17,7 +17,7 @@
 @endsection
 
 @section('page_title')
-    <h2 class="small display_table_cell_md">{{ mb_convert_case($hymn->getName($hymn->original_language_id), MB_CASE_TITLE, 'UTF-8') }}</h2>
+    <h2 class="small display_table_cell_md">{{ !is_null($hymn) ?  mb_convert_case($hymn->getName($hymn->original_language_id), MB_CASE_TITLE, 'UTF-8') : null }}</h2>
     @if (\Illuminate\Support\Facades\Auth::check())
         <div class="hymn-title-add-form">
             <ul class="nav navbar-nav navbar-right add-hymn">
@@ -53,32 +53,34 @@
             <div class="row">
                 <!-- hinario breadcrumbs -->
                 <div class="col-sm-12 col-md-12">
-                    @foreach ($hymn->getHinarios() as $hinario)
-                        @if ($loop->index == 1)
-                            <div class="hinario-breadcrumb-also">{{ __('hymns.breadcrumbs.also_in') }}:</div>
-                        @endif
-                        <div class="@if ($loop->first) hinario-breadcrumb-bold @else hinario-breadcrumb @endif">
-                            @if ($loop->first)
-                                @php
-                                    $previousHymn = $hinario->getPreviousHymn($hymn->id);
-                                @endphp
-                                @if (!empty($previousHymn))
-                                    <a href="{{ url($previousHymn->getSlug()) }}" title="{{ mb_convert_case($previousHymn->getName($previousHymn->original_language_id), MB_CASE_TITLE, 'UTF-8') }}"><i class="far fa-arrow-alt-circle-left"></i> {{ __('hymns.breadcrumbs.previous') }} :: </a>
-                                @endif
+                    @if(!is_null($hymn))
+                        @foreach ($hymn->getHinarios() as $hinario)
+                            @if ($loop->index == 1)
+                                <div class="hinario-breadcrumb-also">{{ __('hymns.breadcrumbs.also_in') }}:</div>
                             @endif
-                            <span class="hinario-breadcrumb-hinario">
-                                <a href="{{ url($hinario->getSlug()) }}">{{ $hinario->getName($hinario->original_language_id) }} #{{ $hymn->getNumber($hinario->id) }}</a>
-                            </span>
-                            @if ($loop->first)
-                                @php
-                                    $nextHymn = $hinario->getNextHymn($hymn->id);
-                                @endphp
-                                @if (!empty($nextHymn))
-                                    <a href="{{ url($nextHymn->getSlug()) }}" title="{{ mb_convert_case($nextHymn->getName($nextHymn->original_language_id), MB_CASE_TITLE, 'UTF-8') }}">:: {{ __('hymns.breadcrumbs.next') }} <i class="far fa-arrow-alt-circle-right"></i></a>
+                            <div class="@if ($loop->first) hinario-breadcrumb-bold @else hinario-breadcrumb @endif">
+                                @if ($loop->first)
+                                    @php
+                                        $previousHymn = $hinario->getPreviousHymn($hymn->id);
+                                    @endphp
+                                    @if (!empty($previousHymn))
+                                        <a href="{{ url($previousHymn->getSlug()) }}" title="{{ mb_convert_case($previousHymn->getName($previousHymn->original_language_id), MB_CASE_TITLE, 'UTF-8') }}"><i class="far fa-arrow-alt-circle-left"></i> {{ __('hymns.breadcrumbs.previous') }} :: </a>
+                                    @endif
                                 @endif
-                            @endif
-                        </div>
-                    @endforeach
+                                <span class="hinario-breadcrumb-hinario">
+                                    <a href="{{ url($hinario->getSlug()) }}">{{ $hinario->getName($hinario->original_language_id) }} #{{ $hymn->getNumber($hinario->id) }}</a>
+                                </span>
+                                @if ($loop->first)
+                                    @php
+                                        $nextHymn = $hinario->getNextHymn($hymn->id);
+                                    @endphp
+                                    @if (!empty($nextHymn))
+                                        <a href="{{ url($nextHymn->getSlug()) }}" title="{{ mb_convert_case($nextHymn->getName($nextHymn->original_language_id), MB_CASE_TITLE, 'UTF-8') }}">:: {{ __('hymns.breadcrumbs.next') }} <i class="far fa-arrow-alt-circle-right"></i></a>
+                                    @endif
+                                @endif
+                            </div>
+                        @endforeach
+                    @endif
                 </div>
             </div>
             <div class="row">
@@ -87,7 +89,7 @@
             </div>
 
             <!-- Language selector -->
-            @if (count($hymn->getSecondaryTranslations()) >1)
+            @if (!is_null($hymn) && count($hymn->getSecondaryTranslations()) >1)
             <div class="row">
                 <div class="col-sm-12 col-md-12 text-right flag-image">
                     <ul class="nav-unstyled darklinks flag-image" role="tablist">
@@ -112,17 +114,19 @@
                 <div class="col-sm-6 col-md-6">
                     <div class="tab-content tab-unstyled">
                         <div class="tab-pane fade in active notranslate" id="tab-unstyled-1000">
-                            @if (view()->exists('hymns.patterns.' . $hymn->pattern_id))
-                                @include('hymns.patterns.' . $hymn->pattern_id, [ 'language' => $hymn->original_language_id ])
-                            @else
-                                @include('hymns.patterns.0', [ 'language' => $hymn->original_language_id ])
+                            @if(!is_null($hymn))
+                                @if (view()->exists('hymns.patterns.' . $hymn->pattern_id))
+                                    @include('hymns.patterns.' . $hymn->pattern_id, [ 'language' => $hymn->original_language_id ])
+                                @else
+                                    @include('hymns.patterns.0', [ 'language' => $hymn->original_language_id ])
+                                @endif
+                                @include('hymns.partials.sun_moon_stars')
                             @endif
-                            @include('hymns.partials.sun_moon_stars')
                         </div>
                     </div>
                 </div>
 
-                @if (count($hymn->getSecondaryTranslations()) > 1)
+                @if (!is_null($hymn) && count($hymn->getSecondaryTranslations()) > 1)
 
                     <!-- Other Translations if there are more than one -->
                     <div class="col-sm-6 col-md-6">
@@ -144,20 +148,22 @@
                 @else
 
                     <!-- Other Translations if there is only one -->
-                    @foreach ($hymn->getSecondaryTranslations() as $translation)
-                        <div class="col-sm-6 col-md-6">
-                            <div class="tab-content tab-unstyled">
-                                <div class="tab-pane fade in active" id="tab-unstyled-1000">
-                                    @if (view()->exists('hymns.patterns.' . $translation->hymn->pattern_id))
-                                        @include('hymns.patterns.' . $translation->hymn->pattern_id, [ 'language' => $translation->language_id ])
-                                    @else
-                                        @include('hymns.patterns.0', [ 'language' => $translation->language_id ])
-                                    @endif
+                    @if (!is_null($hymn) )
+                        @foreach ($hymn->getSecondaryTranslations() as $translation)
+                            <div class="col-sm-6 col-md-6">
+                                <div class="tab-content tab-unstyled">
+                                    <div class="tab-pane fade in active" id="tab-unstyled-1000">
+                                        @if (view()->exists('hymns.patterns.' . $translation->hymn->pattern_id))
+                                            @include('hymns.patterns.' . $translation->hymn->pattern_id, [ 'language' => $translation->language_id ])
+                                        @else
+                                            @include('hymns.patterns.0', [ 'language' => $translation->language_id ])
+                                        @endif
+                                    </div>
+                                    @include('hymns.partials.sun_moon_stars')
                                 </div>
-                                @include('hymns.partials.sun_moon_stars')
                             </div>
-                        </div>
-                    @endforeach
+                        @endforeach
+                    @endif
 
                 @endif
             </div> <!-- end lyrics -->
@@ -191,19 +197,26 @@
 <div class="row">
 <div class="vertical-item content-absolute ds rounded overflow_hidden">
 <div class="item-media">
+@if (!is_null($hymn) )
 <img src="{{ url($hymn->receivedBy->getPortrait()) }}">
+@endif
 </div>
 </div>
 <br>
 @include('layouts.partials.other_media', [ 'entity' => $hymn ])
 
+@if (!is_null($hymn) )
 @include('layouts.partials.feedback_form', [ 'entityType' => 'hymn', 'entityId' => $hymn->id ])
+@endif
+
 </div>
 <div class="row">
 <div class="col-sm-8 col-md-12 col-lg-12 padding-top-20 text-center">
 <!-- feedback form -->
 @if (\Illuminate\Support\Facades\Auth::check() && \Illuminate\Support\Facades\Auth::user()->hasRole('superadmin'))
-@include('admin.layouts.partials.add_media_form', [ 'entityType' => 'hymn', 'entityId' => $hymn->id ])
+    @if (!is_null($hymn) )
+        @include('admin.layouts.partials.add_media_form', [ 'entityType' => 'hymn', 'entityId' => $hymn->id ])
+    @endif
 @endif
 </div>
 </div>

--- a/resources/views/hymns/partials/audio_block_display.blade.php
+++ b/resources/views/hymns/partials/audio_block_display.blade.php
@@ -1,4 +1,4 @@
-@if (count($hymn->getRecordings()) > 0)
+@if ( !is_null($hymn) && count($hymn->getRecordings()) > 0)
     <div class="col-sm-12 col-md-12 text-left">
         @include('hymns.partials.audio_file_display', ['mediaFile' => $hymn->getRecordings()[0]])
 

--- a/resources/views/layouts/partials/other_media.blade.php
+++ b/resources/views/layouts/partials/other_media.blade.php
@@ -1,4 +1,4 @@
-@if (count($entity->getOtherMedia()) > 0)
+@if ( !is_null($entity) && count($entity->getOtherMedia()) > 0)
     <ul class="list2 downloadlist">
         @foreach ($entity->getOtherMedia() as $media)
             <li>

--- a/resources/views/layouts/partials/other_media_hinario.blade.php
+++ b/resources/views/layouts/partials/other_media_hinario.blade.php
@@ -3,7 +3,7 @@
         @foreach ($entity->otherMedia as $media)
             <li>
                 <a href="{{ url($media->url) }}">{{ $media->filename }}</a><br>
-                {{ __('hinarios.source') }} <a href="{{ $media->source->url }}" target="_blank">{{ $media->source->getDescription() }}</a>
+                {{ __('hinarios.source') }} <a href="{{ $media->source->url }}" target="_blank">{{-- $media->source->getDescription() --}} Source</a>
             </li>
         @endforeach
     </ul>

--- a/resources/views/layouts/partials/other_media_hinario.blade.php
+++ b/resources/views/layouts/partials/other_media_hinario.blade.php
@@ -1,4 +1,4 @@
-@if (count($entity->otherMedia) > 0)
+@if (!is_null($entity) && count($entity->otherMedia) > 0)
     <ul class="list2 downloadlist">
         @foreach ($entity->otherMedia as $media)
             <li>


### PR DESCRIPTION
I've updated the code to check for null values for $hymn, etc.  I feel like this is a problem with livewire - somehow, it retrieves the views twice but doesn't send the data the second time; this is the hack I've implemented, checking for null values of variables throughout various views.

Maybe this will help with the 503 errors.  If we implement this soon, I can look through the logs more and fix other errors that crop up.